### PR TITLE
Use reusable CI workflow instead of custom one

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,55 +2,8 @@ name: PR
 
 on:
     pull_request:
-        branches: [ main ]
+        branches: [ $default-branch ]
 
 jobs:
-    android-lint:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-java@v4
-              with:
-                  java-version: 17
-                  distribution: 'temurin'
-            - name: Run Android lint
-              id: lint
-              run: ./gradlew lint
-            - name: Update baseline
-              if: ${{ failure() && steps.lint.conclusion == 'failure' }}
-              run: ./gradlew updateLintBaseline
-            - name: Upload new baseline
-              uses: actions/upload-artifact@v4
-              if: ${{ failure() && steps.lint.conclusion == 'failure' }}
-              with:
-                  name: 'new-lint-baseline'
-                  path: 'app/lint-baseline.xml'
-            - name: Upload results
-              uses: actions/upload-artifact@v4
-              if: ${{ !cancelled() }}
-              with:
-                  name: 'lint-results'
-                  path: 'app/build/intermediates/lint_intermediate_text_report/coreDebug/lint-results-coreDebug.txt'
-
-
-    detekt:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-java@v4
-              with:
-                  java-version: 17
-                  distribution: 'temurin'
-            - name: Run detekt checks
-              run: ./gradlew detekt
-
-    test:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-java@v4
-              with:
-                  java-version: 17
-                  distribution: 'temurin'
-            - name: Run tests
-              run: ./gradlew :app:testCoreDebugUnitTest
+    call-pr-workflow:
+        uses: FossifyOrg/.github/.github/workflows/pr.yml@main

--- a/.github/workflows/testing-build.yml
+++ b/.github/workflows/testing-build.yml
@@ -2,24 +2,9 @@ name: Testing build (on PR)
 
 on:
     pull_request:
-        branches: [ main ]
+        branches: [ $default-branch ]
         types: [ labeled, opened, synchronize, reopened ]
 
 jobs:
-    testing_build:
-        runs-on: ubuntu-latest
-        if: contains(github.event.pull_request.labels.*.name, 'testers needed')
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-java@v4
-              with:
-                  java-version: 17
-                  distribution: 'temurin'
-            - name: Build debug APK
-              run: ./gradlew assemblePrepaidDebug
-            - name: Upload APK
-              id: upload
-              uses: actions/upload-artifact@v4
-              with:
-                  name: 'unsigned-app-debug'
-                  path: 'app/build/outputs/apk/**/*.apk'
+    call-testing-build-workflow:
+        uses: FossifyOrg/.github/.github/workflows/testing-build.yml@main


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix
- [ ] Feature
- [x] Codebase improvement

#### Description of the changes in your PR
- Changed existing CI workflow to use the reusable workflows from https://github.com/FossifyOrg/.github (Added in [PR #7](https://github.com/FossifyOrg/.github/pull/7)). The resulting workflow should be the same, but this lets us change it in one spot for all the applications.

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Launcher/blob/main/CONTRIBUTING.md).
