### PR TITLE
Make sure tap outside of open group closes group

### DIFF
--- a/app/src/main/kotlin/org/fossify/home/views/HomeScreenGrid.kt
+++ b/app/src/main/kotlin/org/fossify/home/views/HomeScreenGrid.kt
@@ -1317,6 +1317,11 @@ class HomeScreenGrid(context: Context, attrs: AttributeSet, defStyle: Int) : Rel
             }
         }
 
+        // if a folder is open, we only want to allow clicks on items in the folder
+        if (currentlyOpenFolder != null) {
+            return null
+        }
+
         for (gridItem in gridItems.filterVisibleOnCurrentPageOnly()) {
             if (gridItem.outOfBounds()) {
                 continue


### PR DESCRIPTION
#### What is it?
- [x] Bugfix

#### Description of the changes in your PR
To ensure the group is always closed, we return `null` in the grid item finder if there is an open folder and no item in the folder was clicked.

#### Before/After Screenshots/Screen Record
- Before:
- After:

#### Fixes the following issue(s)
Fixes #57

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Launcher/blob/main/CONTRIBUTING.md).