### PR TITLE
Lower min. API to 24 (Nougat 7.0)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ gradlePlugins-agp = "8.6.1"
 #build
 app-build-compileSDKVersion = "34"
 app-build-targetSDK = "34"
-app-build-minimumSDK = "26"
+app-build-minimumSDK = "24"
 app-build-javaVersion = "VERSION_17"
 app-build-kotlinJVMTarget = "17"
 #versioning


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [ ] Bugfix
- [x] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Lowered minimum required Android API to 26 (Nougat 7.0) to support more Android devices, my device is a Mediatek device with Android 7.0 as latest Android version, I really liked this launcher on my other Android 9.0, it is one of the really light weight launchers out there, please continue keeping it this simple without complicating it, it is simple, it is functional, KISS is also good, but to me is less usable, yours is simple and works great, not sure if lowering API to 26 causes any issues, no issues were reported in Android Studio, and works great on phone, I was going to try and lower it more, but didn't want to make a change that I cannot physically test (emulators exist but my internet is slow)

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Launcher/blob/main/CONTRIBUTING.md).
