### PR TITLE
Fix scroll down performance

### DIFF
--- a/app/src/main/kotlin/org/fossify/home/fragments/AllAppsFragment.kt
+++ b/app/src/main/kotlin/org/fossify/home/fragments/AllAppsFragment.kt
@@ -113,7 +113,10 @@ class AllAppsFragment(
                     shouldIntercept =
                         distance > 0 && binding.allAppsGrid.computeVerticalScrollOffset() == 0
                     if (shouldIntercept) {
-                        activity?.hideKeyboard()
+                        // Hiding is expensive, only do it if focused
+                        if (binding.searchBar.hasFocus()) {
+                            activity?.hideKeyboard()
+                        }
                         activity?.startHandlingTouches(touchDownY)
                         touchDownY = -1
                     }
@@ -221,7 +224,8 @@ class AllAppsFragment(
         binding.allAppsFastscroller.setPadding(leftListPadding, 0, rightListPadding, 0)
         binding.allAppsGrid.addOnScrollListener(object : OnScrollListener() {
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
-                if (dy > 0 && binding.allAppsGrid.computeVerticalScrollOffset() > 0) {
+                // Hiding is expensive, only do it if focused
+                if (binding.searchBar.hasFocus() && dy > 0 && binding.allAppsGrid.computeVerticalScrollOffset() > 0) {
                     activity?.hideKeyboard()
                 }
             }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [X] Bugfix

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Fix scrolling down performance

Scrolling down was slow (see issue #65) because the keyboard was being hidden every time there was a scroll down event. Hiding the keyboard is an expensive operation (found through profiling). They keyboard only needs to be hidden if the search bar is being used (in focus).

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
The before and after was captured with HWUI turned on and scrolling up and down. Notice that the bars look the same in the after and are a lot shorter.

- Before:

<img alt="Fossify Launcher scroll down vs scroll up performance HWUI (scaled)" src="https://github.com/user-attachments/assets/68f545dc-919b-4215-a397-7a168b4c4f88" width=179 />

- After:

<img alt="Fossify Launcher scroll down vs scroll up performance HWUI after" src="https://github.com/user-attachments/assets/91533219-cbcc-491e-a739-de74105e74bd" width=180 />

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #65

#### Acknowledgement
- [X] I read the [contribution guidelines](https://github.com/FossifyOrg/Launcher/blob/main/CONTRIBUTING.md).