### PR TITLE
Launch hidden application when single tapped

### DIFF
--- a/app/src/main/kotlin/org/fossify/home/activities/HiddenIconsActivity.kt
+++ b/app/src/main/kotlin/org/fossify/home/activities/HiddenIconsActivity.kt
@@ -15,6 +15,7 @@ import org.fossify.home.databinding.ActivityHiddenIconsBinding
 import org.fossify.home.extensions.config
 import org.fossify.home.extensions.getDrawableForPackageName
 import org.fossify.home.extensions.hiddenIconsDB
+import org.fossify.home.extensions.launchApp
 import org.fossify.home.models.HiddenIcon
 
 class HiddenIconsActivity : SimpleActivity(), RefreshRecyclerViewListener {
@@ -85,6 +86,7 @@ class HiddenIconsActivity : SimpleActivity(), RefreshRecyclerViewListener {
 
             runOnUiThread {
                 HiddenIconsAdapter(this, hiddenIcons, this, binding.manageHiddenIconsList) {
+                    launchApp((it as HiddenIcon).packageName, it.activityName)
                 }.apply {
                     binding.manageHiddenIconsList.adapter = this
                 }


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix
- [X] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
At the "Manage hidden icons" section, single tapping an application will now launch it.
Without this change, nothing would happen when single tapping.

#### Fixes the following issue(s)
- Fixes https://github.com/FossifyOrg/Launcher/issues/42

#### Acknowledgement
- [X] I read the [contribution guidelines](https://github.com/FossifyOrg/Launcher/blob/main/CONTRIBUTING.md).

I also read the part that if the Issue have the `needs triage` label then the PR is less likely to get merged.
But I found this feature useful and the Issue had a few thumbs up, so it looks like other people are also interested.