### PR TITLE
Add double tap to lock the phone

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -431,5 +431,17 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity-alias>
+
+        <receiver
+            android:name=".receivers.LockDeviceAdminReceiver"
+            android:exported="true"
+            android:permission="android.permission.BIND_DEVICE_ADMIN">
+            <meta-data
+                android:name="android.app.device_admin"
+                android:resource="@xml/device_admin_policies" />
+            <intent-filter>
+                <action android:name="android.app.action.DEVICE_ADMIN_ENABLED" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/app/src/main/kotlin/org/fossify/home/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/fossify/home/activities/SettingsActivity.kt
@@ -1,6 +1,9 @@
 package org.fossify.home.activities
 
 import android.annotation.SuppressLint
+import android.app.admin.DevicePolicyManager
+import android.content.ComponentName
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import org.fossify.commons.dialogs.RadioGroupDialog
@@ -26,6 +29,7 @@ import org.fossify.home.helpers.MAX_ROW_COUNT
 import org.fossify.home.helpers.MIN_COLUMN_COUNT
 import org.fossify.home.helpers.MIN_ROW_COUNT
 import org.fossify.home.helpers.REPOSITORY_NAME
+import org.fossify.home.receivers.LockDeviceAdminReceiver
 import java.util.Locale
 import kotlin.system.exitProcess
 
@@ -55,6 +59,7 @@ class SettingsActivity : SimpleActivity() {
         setupPurchaseThankYou()
         setupCustomizeColors()
         setupUseEnglish()
+        setupDoubleTapToLock()
         setupCloseAppDrawerOnOtherAppOpen()
         setupDrawerColumnCount()
         setupDrawerSearchBar()
@@ -113,6 +118,33 @@ class SettingsActivity : SimpleActivity() {
             binding.settingsUseEnglish.toggle()
             config.useEnglish = binding.settingsUseEnglish.isChecked
             exitProcess(0)
+        }
+    }
+
+    private fun setupDoubleTapToLock() {
+        val devicePolicyManager =
+            getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
+        val isLockDeviceAdminActive = devicePolicyManager.isAdminActive(
+            ComponentName(this, LockDeviceAdminReceiver::class.java)
+        )
+        binding.settingsDoubleTapToLock.isChecked = isLockDeviceAdminActive
+        binding.settingsDoubleTapToLock.setOnClickListener {
+            if (isLockDeviceAdminActive) {
+                devicePolicyManager.removeActiveAdmin(
+                    ComponentName(this, LockDeviceAdminReceiver::class.java)
+                )
+            } else {
+                val intent = Intent(DevicePolicyManager.ACTION_ADD_DEVICE_ADMIN)
+                intent.putExtra(
+                    DevicePolicyManager.EXTRA_DEVICE_ADMIN,
+                    ComponentName(this, LockDeviceAdminReceiver::class.java)
+                )
+                intent.putExtra(
+                    DevicePolicyManager.EXTRA_ADD_EXPLANATION,
+                    getString(R.string.lock_device_admin_hint)
+                )
+                startActivity(intent)
+            }
         }
     }
 

--- a/app/src/main/kotlin/org/fossify/home/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/fossify/home/activities/SettingsActivity.kt
@@ -124,11 +124,13 @@ class SettingsActivity : SimpleActivity() {
     private fun setupDoubleTapToLock() {
         val devicePolicyManager =
             getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
-        val isLockDeviceAdminActive = devicePolicyManager.isAdminActive(
+        binding.settingsDoubleTapToLock.isChecked = devicePolicyManager.isAdminActive(
             ComponentName(this, LockDeviceAdminReceiver::class.java)
         )
-        binding.settingsDoubleTapToLock.isChecked = isLockDeviceAdminActive
         binding.settingsDoubleTapToLock.setOnClickListener {
+            val isLockDeviceAdminActive = devicePolicyManager.isAdminActive(
+                ComponentName(this, LockDeviceAdminReceiver::class.java)
+            )
             if (isLockDeviceAdminActive) {
                 devicePolicyManager.removeActiveAdmin(
                     ComponentName(this, LockDeviceAdminReceiver::class.java)

--- a/app/src/main/kotlin/org/fossify/home/receivers/LockDeviceAdminReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/home/receivers/LockDeviceAdminReceiver.kt
@@ -1,0 +1,13 @@
+package org.fossify.home.receivers
+
+import android.app.admin.DeviceAdminReceiver
+import android.content.Context
+import android.content.Intent
+import org.fossify.home.R
+
+class LockDeviceAdminReceiver : DeviceAdminReceiver() {
+
+    override fun onDisableRequested(context: Context, intent: Intent): CharSequence {
+        return context.getString(R.string.lock_device_admin_warning)
+    }
+}

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -97,22 +97,6 @@
             </RelativeLayout>
 
             <RelativeLayout
-                android:id="@+id/settings_double_tap_to_lock_holder"
-                style="@style/SettingsHolderSwitchStyle"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@drawable/ripple_background">
-
-                <org.fossify.commons.views.MyMaterialSwitch
-                    android:id="@+id/settings_double_tap_to_lock"
-                    style="@style/SettingsSwitchStyle"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/double_tap_to_lock" />
-
-            </RelativeLayout>
-
-            <RelativeLayout
                 android:id="@+id/settings_language_holder"
                 style="@style/SettingsHolderTextViewStyle"
                 android:layout_width="match_parent"
@@ -149,6 +133,22 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/manage_hidden_icons" />
+
+            </RelativeLayout>
+
+            <RelativeLayout
+                android:id="@+id/settings_double_tap_to_lock_holder"
+                style="@style/SettingsHolderSwitchStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/ripple_background">
+
+                <org.fossify.commons.views.MyMaterialSwitch
+                    android:id="@+id/settings_double_tap_to_lock"
+                    style="@style/SettingsSwitchStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/double_tap_to_lock" />
 
             </RelativeLayout>
 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -97,6 +97,22 @@
             </RelativeLayout>
 
             <RelativeLayout
+                android:id="@+id/settings_double_tap_to_lock_holder"
+                style="@style/SettingsHolderSwitchStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/ripple_background">
+
+                <org.fossify.commons.views.MyMaterialSwitch
+                    android:id="@+id/settings_double_tap_to_lock"
+                    style="@style/SettingsSwitchStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/double_tap_to_lock" />
+
+            </RelativeLayout>
+
+            <RelativeLayout
                 android:id="@+id/settings_language_holder"
                 style="@style/SettingsHolderTextViewStyle"
                 android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,9 +14,9 @@
     <string name="close_app_drawer_on_app_open">Close app drawer on opening an app</string>
     <string name="home_screen_settings">Home screen</string>
     <string name="widget_too_big">Widget is too big for current home screen size</string>
-    <string name="double_tap_to_lock">Double tap to lock</string>
-    <string name="lock_device_admin_hint">To use double tap to lock you need to grant admin permission.</string>
-    <string name="lock_device_admin_warning">Double tap to lock will be turned off.</string>
+    <string name="double_tap_to_lock">Double tap to lock the screen</string>
+    <string name="lock_device_admin_hint">To use double tap to lock the screen, you need to grant the admin permission.</string>
+    <string name="lock_device_admin_warning">Double tap to lock the screen will be turned off.</string>
     <!--
         Haven't found some strings? There's more at
         https://github.com/FossifyOrg/Commons/tree/master/commons/src/main/res

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,9 +14,9 @@
     <string name="close_app_drawer_on_app_open">Close app drawer on opening an app</string>
     <string name="home_screen_settings">Home screen</string>
     <string name="widget_too_big">Widget is too big for current home screen size</string>
-    <string name="double_tap_to_lock">Double tap to lock the screen</string>
-    <string name="lock_device_admin_hint">To use double tap to lock the screen, you need to grant the admin permission.</string>
-    <string name="lock_device_admin_warning">Double tap to lock the screen will be turned off.</string>
+    <string name="double_tap_to_lock">Double tap to lock screen</string>
+    <string name="lock_device_admin_hint">To enable the double tap to lock screen feature, you need to grant admin permission. Note that the app cannot be uninstalled until this permission is removed.</string>
+    <string name="lock_device_admin_warning">Deactivating admin permission will disable the double tap to lock screen feature.</string>
     <!--
         Haven't found some strings? There's more at
         https://github.com/FossifyOrg/Commons/tree/master/commons/src/main/res

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,9 @@
     <string name="close_app_drawer_on_app_open">Close app drawer on opening an app</string>
     <string name="home_screen_settings">Home screen</string>
     <string name="widget_too_big">Widget is too big for current home screen size</string>
+    <string name="double_tap_to_lock">Double tap to lock</string>
+    <string name="lock_device_admin_hint">To use double tap to lock you need to grant admin permission.</string>
+    <string name="lock_device_admin_warning">Double tap to lock will be turned off.</string>
     <!--
         Haven't found some strings? There's more at
         https://github.com/FossifyOrg/Commons/tree/master/commons/src/main/res

--- a/app/src/main/res/xml/device_admin_policies.xml
+++ b/app/src/main/res/xml/device_admin_policies.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device-admin>
+    <uses-policies>
+        <force-lock />
+    </uses-policies>
+</device-admin>


### PR DESCRIPTION
#### What is it?
- [X] Feature

#### Description of the changes in your PR
- When double tapping at an empty space on the _Home Screen_, it locks the phone.
- A new option was added at the _Settings_ menu to enable this feature.
- This feature requires _Device Admin Permission_ to allow locking the phone.
- Three new strings were added for this feature.
  - **double_tap_to_lock** : Text for the settings option.
  - **lock_device_admin_hint** : Text displayed by Android when agreeing with the _Device Admin Permissions_.
  - **lock_device_admin_warning** : Text displayed by Android when disabling _Device Admin Permissions_ for the _App_ at _Android Settings_.

I see the strings translation for this project are done by _Weblate_, but I don't know how it's done.
I only added the default strings at `strings.xml`, if I need to make additional changes, let me know.

#### Before/After Screenshots/Screen Record
Below screenshots are only related to the new option added at _Settings_ to enable the _Double Tap to Lock_ feature.
The actual feature doesn't change/add any new UI elements.

- Before:
<img alt="before" src="https://github.com/user-attachments/assets/80a18246-fc7b-40a2-8880-e2f5fbcfd119" width=184 />
- After:
<img alt="after" src="https://github.com/user-attachments/assets/b99af25c-666f-416f-a7b4-dc6d957cf99f" width=184 />

#### Fixes the following issue(s)
- Fixes https://github.com/FossifyOrg/Launcher/issues/63

#### Acknowledgement
- [X] I read the [contribution guidelines](https://github.com/FossifyOrg/Launcher/blob/main/CONTRIBUTING.md).
