### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 Changelog
 ==========
 
-Version 1.0.0 *(2025-01-01)*
+Version 1.1.0 *(2025-03-19)*
+----------------------------
+
+* Added double tap to lock screen feature (https://github.com/FossifyOrg/Launcher/issues/63)
+* Added more translations
+
+Version 1.0.1 *(2025-01-01)*
 ----------------------------
 
 * Fixed scrolling performance issues (https://github.com/FossifyOrg/Launcher/issues/65)

--- a/app/src/main/kotlin/org/fossify/home/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/fossify/home/activities/SettingsActivity.kt
@@ -3,7 +3,6 @@ package org.fossify.home.activities
 import android.annotation.SuppressLint
 import android.app.admin.DevicePolicyManager
 import android.content.ComponentName
-import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import org.fossify.commons.dialogs.RadioGroupDialog
@@ -28,7 +27,6 @@ import org.fossify.home.helpers.MAX_COLUMN_COUNT
 import org.fossify.home.helpers.MAX_ROW_COUNT
 import org.fossify.home.helpers.MIN_COLUMN_COUNT
 import org.fossify.home.helpers.MIN_ROW_COUNT
-import org.fossify.home.helpers.REPOSITORY_NAME
 import org.fossify.home.receivers.LockDeviceAdminReceiver
 import java.util.Locale
 import kotlin.system.exitProcess
@@ -112,7 +110,11 @@ class SettingsActivity : SimpleActivity() {
     }
 
     private fun setupUseEnglish() {
-        binding.settingsUseEnglishHolder.beVisibleIf((config.wasUseEnglishToggled || Locale.getDefault().language != "en") && !isTiramisuPlus())
+        binding.settingsUseEnglishHolder.beVisibleIf(
+            beVisible = (config.wasUseEnglishToggled || Locale.getDefault().language != "en")
+                    && !isTiramisuPlus()
+        )
+
         binding.settingsUseEnglish.isChecked = config.useEnglish
         binding.settingsUseEnglishHolder.setOnClickListener {
             binding.settingsUseEnglish.toggle()
@@ -122,12 +124,12 @@ class SettingsActivity : SimpleActivity() {
     }
 
     private fun setupDoubleTapToLock() {
-        val devicePolicyManager =
-            getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
+        val devicePolicyManager = getSystemService(DEVICE_POLICY_SERVICE) as DevicePolicyManager
         binding.settingsDoubleTapToLock.isChecked = devicePolicyManager.isAdminActive(
             ComponentName(this, LockDeviceAdminReceiver::class.java)
         )
-        binding.settingsDoubleTapToLock.setOnClickListener {
+
+        binding.settingsDoubleTapToLockHolder.setOnClickListener {
             val isLockDeviceAdminActive = devicePolicyManager.isAdminActive(
                 ComponentName(this, LockDeviceAdminReceiver::class.java)
             )

--- a/app/src/main/kotlin/org/fossify/home/extensions/Activity.kt
+++ b/app/src/main/kotlin/org/fossify/home/extensions/Activity.kt
@@ -9,7 +9,6 @@ import android.content.pm.LauncherApps
 import android.content.res.ColorStateList
 import android.graphics.Color
 import android.graphics.Rect
-import android.graphics.drawable.ColorDrawable
 import android.net.Uri
 import android.os.Process
 import android.provider.Settings
@@ -90,7 +89,7 @@ fun Activity.handleGridItemPopupMenu(
     anchorView: View,
     gridItem: HomeScreenGridItem,
     isOnAllAppsFragment: Boolean,
-    listener: ItemMenuListener
+    listener: ItemMenuListener,
 ): PopupMenu {
     val contextTheme = ContextThemeWrapper(this, getPopupMenuTheme())
     return PopupMenu(contextTheme, anchorView, Gravity.TOP or Gravity.END).apply {
@@ -114,8 +113,9 @@ fun Activity.handleGridItemPopupMenu(
             gridItem.type == ITEM_TYPE_ICON && isOnAllAppsFragment
         menu.findItem(R.id.resize).isVisible = gridItem.type == ITEM_TYPE_WIDGET
         menu.findItem(R.id.app_info).isVisible = gridItem.type == ITEM_TYPE_ICON
-        menu.findItem(R.id.uninstall).isVisible =
-            gridItem.type == ITEM_TYPE_ICON && canAppBeUninstalled(gridItem.packageName)
+        menu.findItem(R.id.uninstall).isVisible = gridItem.type == ITEM_TYPE_ICON
+                && canAppBeUninstalled(gridItem.packageName)
+                && gridItem.packageName != packageName
         menu.findItem(R.id.remove).isVisible = !isOnAllAppsFragment
 
         val launcherApps =
@@ -145,7 +145,7 @@ fun Activity.handleGridItemPopupMenu(
 
                 menu.add(R.id.group_shortcuts, Menu.NONE, Menu.NONE, shortcutInfo.getLabel())
                     .setIcon(
-                        (iconDrawable ?: ColorDrawable(Color.TRANSPARENT))
+                        (iconDrawable ?: Color.TRANSPARENT.toDrawable())
                             .toBitmap(width = iconSize, height = iconSize)
                             .toDrawable(resources)
                     )

--- a/fastlane/metadata/android/en-US/changelogs/3.txt
+++ b/fastlane/metadata/android/en-US/changelogs/3.txt
@@ -1,0 +1,2 @@
+* Added double tap to lock screen feature
+* Added more translations

--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,1 +1,1 @@
-Fossify Launcher
+Fossify Launcher Beta

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,8 +19,8 @@ app-build-javaVersion = "VERSION_17"
 app-build-kotlinJVMTarget = "17"
 #versioning
 app-version-appId = "org.fossify.home"
-app-version-versionCode = "2"
-app-version-versionName = "1.0.1"
+app-version-versionCode = "3"
+app-version-versionName = "1.1.0"
 [libraries]
 #Room
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }


### PR DESCRIPTION

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Removed uninstall option for launcher settings icon as it conflicts with the double tap to lock feature.
- Fixed ripples for double tap to lock preference
- Updated version to 1.1.0

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Launcher/blob/main/CONTRIBUTING.md).
