### PR TITLE
Disable R8 obfuscation for more useful stacktraces

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,9 @@
+# Preserve the line number information for debugging stack traces.
+-keepattributes SourceFile,LineNumberTable
+# Preserve class names.
+-dontobfuscate
+# keepattributes only applies to classes matched by keep rules.
+# Put a very weak keep rule here to ensure it applies everywhere.
+-keep,allowshrinking,allowoptimization class * {
+    *;
+}


### PR DESCRIPTION
#### What is it?
- [x] Feature

#### Description of the changes in your PR

At the moment release stacktraces are heavily obfuscated.

This simple change keeps debugging information (file/class names, line numbers) whilst still allowing all shrinking and optimizations.

#### Before/After Screenshots/Screen Record
N/A

#### Fixes the following issue(s)
I did not open an issue first, as this should be an uncontroversial fix.

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Launcher/blob/main/CONTRIBUTING.md).