### PR TITLE
feat: prompt to set as default on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- The app will now prompt to set as default launcher on startup ([#230])
 
 ## [1.2.0] - 2025-07-15
 ### Added
@@ -68,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#106]: https://github.com/FossifyOrg/Launcher/issues/106
 [#115]: https://github.com/FossifyOrg/Launcher/issues/115
 [#182]: https://github.com/FossifyOrg/Launcher/issues/182
+[#230]: https://github.com/FossifyOrg/Launcher/issues/230
 
 [Unreleased]: https://github.com/FossifyOrg/Launcher/compare/1.2.0...HEAD
 [1.2.0]: https://github.com/FossifyOrg/Launcher/compare/1.1.4...1.2.0

--- a/app/src/main/kotlin/org/fossify/home/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/home/activities/MainActivity.kt
@@ -21,6 +21,7 @@ import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.provider.Settings
 import android.provider.Telephony
 import android.telecom.TelecomManager
 import android.view.ContextThemeWrapper
@@ -163,6 +164,10 @@ class MainActivity : SimpleActivity(), FlingListener {
                 x = binding.homeScreenGrid.root.getClickableRect(it).left.toFloat(),
                 clickedGridItem = it
             )
+        }
+
+        if (!isDefaultLauncher()) {
+            requestHomeRole()
         }
     }
 
@@ -775,7 +780,7 @@ class MainActivity : SimpleActivity(), FlingListener {
             Gravity.TOP or Gravity.END
         ).apply {
             inflate(R.menu.menu_home_screen)
-            menu.findItem(R.id.set_as_default).isVisible = isQPlus() && !isDefaultLauncher()
+            menu.findItem(R.id.set_as_default).isVisible = !isDefaultLauncher()
             setOnMenuItemClickListener { item ->
                 when (item.itemId) {
                     R.id.widgets -> showWidgetsFragment()
@@ -841,6 +846,18 @@ class MainActivity : SimpleActivity(), FlingListener {
     }
 
     private fun launchSetAsDefaultIntent() {
+        val intents = listOf(
+            Intent(Settings.ACTION_HOME_SETTINGS),
+            Intent(Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS),
+            Intent(Settings.ACTION_SETTINGS)
+        )
+        val intent = intents.firstOrNull { it.resolveActivity(packageManager) != null }
+        if (intent != null) {
+            startActivity(intent)
+        }
+    }
+
+    private fun requestHomeRole() {
         if (isQPlus()) {
             startActivityForResult(
                 roleManager.createRequestRoleIntent(RoleManager.ROLE_HOME),


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- The app will now prompt to set as the default launcher on startup on Android 10+ devices.
- To make it more reliable in case of multiple denials, the existing **Long press on home screen** ➜ **Set as default** option now launches the system page for selecting the default home app instead of prompting using the RoleManager API (which only worked on Android 10 and above)

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Launcher/issues/230

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
