### PR TITLE
feat: add support for dual apps with Android profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Pressing enter in app drawer launches the first app in search results ([#331])
+- Support for Dual Apps with Android profiles ([#294])
 
 ## [1.9.0] - 2026-02-02
 ### Added

--- a/app/schemas/org.fossify.home.databases.AppsDatabase/6.json
+++ b/app/schemas/org.fossify.home.databases.AppsDatabase/6.json
@@ -1,0 +1,253 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "0b4887bab45e095e4b130aee2796dec4",
+    "entities": [
+      {
+        "tableName": "apps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `title` TEXT NOT NULL, `package_name` TEXT NOT NULL, `activity_name` TEXT NOT NULL, `user_serial` INTEGER NOT NULL, `order` INTEGER NOT NULL, `thumbnail_color` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activityName",
+            "columnName": "activity_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userSerial",
+            "columnName": "user_serial",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailColor",
+            "columnName": "thumbnail_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_apps_package_name_activity_name_user_serial",
+            "unique": true,
+            "columnNames": [
+              "package_name",
+              "activity_name",
+              "user_serial"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_apps_package_name_activity_name_user_serial` ON `${TABLE_NAME}` (`package_name`, `activity_name`, `user_serial`)"
+          }
+        ]
+      },
+      {
+        "tableName": "home_screen_grid_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `left` INTEGER NOT NULL, `top` INTEGER NOT NULL, `right` INTEGER NOT NULL, `bottom` INTEGER NOT NULL, `page` INTEGER NOT NULL, `package_name` TEXT NOT NULL, `activity_name` TEXT NOT NULL, `user_serial` INTEGER NOT NULL, `title` TEXT NOT NULL, `type` INTEGER NOT NULL, `class_name` TEXT NOT NULL, `widget_id` INTEGER NOT NULL, `shortcut_id` TEXT NOT NULL, `icon` BLOB, `docked` INTEGER NOT NULL, `parent_id` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "left",
+            "columnName": "left",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "top",
+            "columnName": "top",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "right",
+            "columnName": "right",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bottom",
+            "columnName": "bottom",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activityName",
+            "columnName": "activity_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userSerial",
+            "columnName": "user_serial",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "className",
+            "columnName": "class_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "widgetId",
+            "columnName": "widget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortcutId",
+            "columnName": "shortcut_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "docked",
+            "columnName": "docked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parent_id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_home_screen_grid_items_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_home_screen_grid_items_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "hidden_icons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `package_name` TEXT NOT NULL, `activity_name` TEXT NOT NULL, `user_serial` INTEGER NOT NULL, `title` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activityName",
+            "columnName": "activity_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userSerial",
+            "columnName": "user_serial",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_hidden_icons_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_hidden_icons_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '0b4887bab45e095e4b130aee2796dec4')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/org/fossify/home/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/home/activities/MainActivity.kt
@@ -24,6 +24,7 @@ import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.os.UserManager
 import android.provider.Settings
 import android.provider.Telephony
 import android.telecom.TelecomManager
@@ -90,6 +91,7 @@ import org.fossify.home.helpers.REQUEST_ALLOW_BINDING_WIDGET
 import org.fossify.home.helpers.REQUEST_CONFIGURE_WIDGET
 import org.fossify.home.helpers.REQUEST_CREATE_SHORTCUT
 import org.fossify.home.helpers.REQUEST_SET_DEFAULT
+import org.fossify.home.helpers.UNKNOWN_USER_SERIAL
 import org.fossify.home.helpers.UNINSTALL_APP_REQUEST_CODE
 import org.fossify.home.interfaces.FlingListener
 import org.fossify.home.interfaces.ItemMenuListener
@@ -513,6 +515,9 @@ class MainActivity : SimpleActivity(), FlingListener {
                     shortcutInfo,
                     resources.displayMetrics.densityDpi
                 )
+                val userManager = applicationContext.getSystemService(USER_SERVICE) as UserManager
+                val shortcutUserSerial =
+                    userManager.getSerialNumberForUser(shortcutInfo.userHandle)
                 val (page, rect) = findFirstEmptyCell()
                 val gridItem = HomeScreenGridItem(
                     id = null,
@@ -523,6 +528,7 @@ class MainActivity : SimpleActivity(), FlingListener {
                     page = page,
                     packageName = shortcutInfo.`package`,
                     activityName = "",
+                    userSerial = shortcutUserSerial,
                     title = label,
                     type = ITEM_TYPE_SHORTCUT,
                     className = "",
@@ -594,10 +600,19 @@ class MainActivity : SimpleActivity(), FlingListener {
         binding.allAppsFragment.root.gotLaunchers(launchers)
         binding.widgetsFragment.root.getAppWidgets()
 
-        IconCache.launchers.map { it.packageName }.forEach { packageName ->
-            if (!launchers.map { it.packageName }.contains(packageName)) {
-                launchersDB.deleteApp(packageName)
-                homeScreenGridItemsDB.deleteByPackageName(packageName)
+        val newIdentifiers = launchers.map { it.getLauncherIdentifier() }.toHashSet()
+        IconCache.launchers.forEach { cachedLauncher ->
+            if (!newIdentifiers.contains(cachedLauncher.getLauncherIdentifier())) {
+                launchersDB.deleteApp(
+                    cachedLauncher.packageName,
+                    cachedLauncher.activityName,
+                    cachedLauncher.userSerial
+                )
+                homeScreenGridItemsDB.deleteByIdentifier(
+                    cachedLauncher.packageName,
+                    cachedLauncher.activityName,
+                    cachedLauncher.userSerial
+                )
             }
         }
 
@@ -762,7 +777,11 @@ class MainActivity : SimpleActivity(), FlingListener {
 
     private fun performItemClick(clickedGridItem: HomeScreenGridItem) {
         when (clickedGridItem.type) {
-            ITEM_TYPE_ICON -> launchApp(clickedGridItem.packageName, clickedGridItem.activityName)
+            ITEM_TYPE_ICON -> launchApp(
+                clickedGridItem.packageName,
+                clickedGridItem.activityName,
+                clickedGridItem.userSerial
+            )
             ITEM_TYPE_FOLDER -> openFolder(clickedGridItem)
             ITEM_TYPE_SHORTCUT -> {
                 val id = clickedGridItem.shortcutId
@@ -869,7 +888,7 @@ class MainActivity : SimpleActivity(), FlingListener {
 
     private fun hideIcon(item: HomeScreenGridItem) {
         ensureBackgroundThread {
-            val hiddenIcon = HiddenIcon(null, item.packageName, item.activityName, item.title, null)
+            val hiddenIcon = HiddenIcon(null, item.packageName, item.activityName, item.userSerial, item.title, null)
             hiddenIconsDB.insert(hiddenIcon)
 
             runOnUiThread {
@@ -941,7 +960,7 @@ class MainActivity : SimpleActivity(), FlingListener {
         }
 
         override fun appInfo(gridItem: HomeScreenGridItem) {
-            launchAppInfo(gridItem.packageName)
+            launchAppInfo(gridItem.packageName, gridItem.activityName, gridItem.userSerial)
         }
 
         override fun remove(gridItem: HomeScreenGridItem) {
@@ -1073,46 +1092,54 @@ class MainActivity : SimpleActivity(), FlingListener {
         }
 
         val allApps = ArrayList<AppLauncher>()
-        val intent = Intent(Intent.ACTION_MAIN, null)
-        intent.addCategory(Intent.CATEGORY_LAUNCHER)
-
         val simpleLauncher = applicationContext.packageName
         val microG = "com.google.android.gms"
-        val list = packageManager.queryIntentActivities(intent, PackageManager.PERMISSION_GRANTED)
-        for (info in list) {
-            val componentInfo = info.activityInfo.applicationInfo
-            val packageName = componentInfo.packageName
-            if (packageName == simpleLauncher || packageName == microG) {
+        val launcherApps =
+            applicationContext.getSystemService(LAUNCHER_APPS_SERVICE) as LauncherApps
+        val userManager = applicationContext.getSystemService(USER_SERVICE) as UserManager
+        val userHandles = userManager.userProfiles
+        for (userHandle in userHandles) {
+            val userSerial = userManager.getSerialNumberForUser(userHandle)
+            if (userSerial == UNKNOWN_USER_SERIAL) {
                 continue
             }
 
-            val activityName = info.activityInfo.name
-            if (hiddenIcons.contains("$packageName/$activityName")) {
-                continue
-            }
+            val activityList = launcherApps.getActivityList(null, userHandle)
+            for (info in activityList) {
+                val packageName = info.applicationInfo.packageName
+                if (packageName == simpleLauncher || packageName == microG) {
+                    continue
+                }
 
-            val label = info.loadLabel(packageManager).toString()
-            val drawable = info.loadIcon(packageManager)
-                ?: getDrawableForPackageName(packageName)
-                ?: continue
+                val activityName = info.name
+                if (hiddenIcons.contains("$packageName/$activityName/$userSerial")) {
+                    continue
+                }
 
-            val bitmap = drawable.toBitmap(
-                width = max(drawable.intrinsicWidth, 1),
-                height = max(drawable.intrinsicHeight, 1),
-                config = Bitmap.Config.ARGB_8888
-            )
-            val placeholderColor = calculateAverageColor(bitmap)
-            allApps.add(
-                AppLauncher(
-                    id = null,
-                    title = label,
-                    packageName = packageName,
-                    activityName = activityName,
-                    order = 0,
-                    thumbnailColor = placeholderColor,
-                    drawable = bitmap.toDrawable(resources)
+                val label = info.label.toString()
+                val drawable = info.getBadgedIcon(resources.displayMetrics.densityDpi)
+                    ?: getDrawableForPackageName(packageName, userSerial)
+                    ?: continue
+
+                val bitmap = drawable.toBitmap(
+                    width = max(drawable.intrinsicWidth, 1),
+                    height = max(drawable.intrinsicHeight, 1),
+                    config = Bitmap.Config.ARGB_8888
                 )
-            )
+                val placeholderColor = calculateAverageColor(bitmap)
+                allApps.add(
+                    AppLauncher(
+                        id = null,
+                        title = label,
+                        packageName = packageName,
+                        activityName = activityName,
+                        userSerial = userSerial,
+                        order = 0,
+                        thumbnailColor = placeholderColor,
+                        drawable = bitmap.toDrawable(resources)
+                    )
+                )
+            }
         }
 
         launchersDB.insertAll(allApps)
@@ -1121,10 +1148,14 @@ class MainActivity : SimpleActivity(), FlingListener {
 
     private fun getDefaultAppPackages(appLaunchers: ArrayList<AppLauncher>) {
         val homeScreenGridItems = ArrayList<HomeScreenGridItem>()
+        val myUserSerial =
+            (getSystemService(USER_SERVICE) as UserManager).getSerialNumberForUser(android.os.Process.myUserHandle())
         try {
             val defaultDialerPackage =
                 (getSystemService(TELECOM_SERVICE) as TelecomManager).defaultDialerPackage
-            appLaunchers.firstOrNull { it.packageName == defaultDialerPackage }?.apply {
+            appLaunchers.firstOrNull {
+                it.packageName == defaultDialerPackage && it.userSerial == myUserSerial
+            }?.apply {
                 val dialerIcon =
                     HomeScreenGridItem(
                         id = null,
@@ -1135,6 +1166,7 @@ class MainActivity : SimpleActivity(), FlingListener {
                         page = 0,
                         packageName = defaultDialerPackage,
                         activityName = "",
+                        userSerial = userSerial,
                         title = title,
                         type = ITEM_TYPE_ICON,
                         className = "",
@@ -1151,7 +1183,9 @@ class MainActivity : SimpleActivity(), FlingListener {
 
         try {
             val defaultSMSMessengerPackage = Telephony.Sms.getDefaultSmsPackage(this)
-            appLaunchers.firstOrNull { it.packageName == defaultSMSMessengerPackage }?.apply {
+            appLaunchers.firstOrNull {
+                it.packageName == defaultSMSMessengerPackage && it.userSerial == myUserSerial
+            }?.apply {
                 val messengerIcon =
                     HomeScreenGridItem(
                         id = null,
@@ -1162,6 +1196,7 @@ class MainActivity : SimpleActivity(), FlingListener {
                         page = 0,
                         packageName = defaultSMSMessengerPackage,
                         activityName = "",
+                        userSerial = userSerial,
                         title = title,
                         type = ITEM_TYPE_ICON,
                         className = "",
@@ -1181,7 +1216,9 @@ class MainActivity : SimpleActivity(), FlingListener {
             val resolveInfo =
                 packageManager.resolveActivity(browserIntent, PackageManager.MATCH_DEFAULT_ONLY)
             val defaultBrowserPackage = resolveInfo!!.activityInfo.packageName
-            appLaunchers.firstOrNull { it.packageName == defaultBrowserPackage }?.apply {
+            appLaunchers.firstOrNull {
+                it.packageName == defaultBrowserPackage && it.userSerial == myUserSerial
+            }?.apply {
                 val browserIcon =
                     HomeScreenGridItem(
                         id = null,
@@ -1192,6 +1229,7 @@ class MainActivity : SimpleActivity(), FlingListener {
                         page = 0,
                         packageName = defaultBrowserPackage,
                         activityName = "",
+                        userSerial = userSerial,
                         title = title,
                         type = ITEM_TYPE_ICON,
                         className = "",
@@ -1214,7 +1252,9 @@ class MainActivity : SimpleActivity(), FlingListener {
                 isPackageInstalled(it) && appLaunchers.map { it.packageName }.contains(it)
             }
             if (storePackage != null) {
-                appLaunchers.firstOrNull { it.packageName == storePackage }?.apply {
+                appLaunchers.firstOrNull {
+                    it.packageName == storePackage && it.userSerial == myUserSerial
+                }?.apply {
                     val storeIcon = HomeScreenGridItem(
                         id = null,
                         left = 3,
@@ -1224,6 +1264,7 @@ class MainActivity : SimpleActivity(), FlingListener {
                         page = 0,
                         packageName = storePackage,
                         activityName = "",
+                        userSerial = userSerial,
                         title = title,
                         type = ITEM_TYPE_ICON,
                         className = "",
@@ -1244,7 +1285,9 @@ class MainActivity : SimpleActivity(), FlingListener {
             val resolveInfo =
                 packageManager.resolveActivity(cameraIntent, PackageManager.MATCH_DEFAULT_ONLY)
             val defaultCameraPackage = resolveInfo!!.activityInfo.packageName
-            appLaunchers.firstOrNull { it.packageName == defaultCameraPackage }?.apply {
+            appLaunchers.firstOrNull {
+                it.packageName == defaultCameraPackage && it.userSerial == myUserSerial
+            }?.apply {
                 val cameraIcon =
                     HomeScreenGridItem(
                         id = null,
@@ -1255,6 +1298,7 @@ class MainActivity : SimpleActivity(), FlingListener {
                         page = 0,
                         packageName = defaultCameraPackage,
                         activityName = "",
+                        userSerial = userSerial,
                         title = title,
                         type = ITEM_TYPE_ICON,
                         className = "",

--- a/app/src/main/kotlin/org/fossify/home/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/home/activities/MainActivity.kt
@@ -1150,171 +1150,129 @@ class MainActivity : SimpleActivity(), FlingListener {
         val homeScreenGridItems = ArrayList<HomeScreenGridItem>()
         val myUserSerial =
             (getSystemService(USER_SERVICE) as UserManager).getSerialNumberForUser(android.os.Process.myUserHandle())
-        try {
-            val defaultDialerPackage =
-                (getSystemService(TELECOM_SERVICE) as TelecomManager).defaultDialerPackage
-            appLaunchers.firstOrNull {
-                it.packageName == defaultDialerPackage && it.userSerial == myUserSerial
-            }?.apply {
-                val dialerIcon =
-                    HomeScreenGridItem(
-                        id = null,
-                        left = 0,
-                        top = config.homeRowCount - 1,
-                        right = 0,
-                        bottom = config.homeRowCount - 1,
-                        page = 0,
-                        packageName = defaultDialerPackage,
-                        activityName = "",
-                        userSerial = userSerial,
-                        title = title,
-                        type = ITEM_TYPE_ICON,
-                        className = "",
-                        widgetId = -1,
-                        shortcutId = "",
-                        icon = null,
-                        docked = true,
-                        parentId = null
-                    )
-                homeScreenGridItems.add(dialerIcon)
-            }
-        } catch (_: Exception) {
-        }
-
-        try {
-            val defaultSMSMessengerPackage = Telephony.Sms.getDefaultSmsPackage(this)
-            appLaunchers.firstOrNull {
-                it.packageName == defaultSMSMessengerPackage && it.userSerial == myUserSerial
-            }?.apply {
-                val messengerIcon =
-                    HomeScreenGridItem(
-                        id = null,
-                        left = 1,
-                        top = config.homeRowCount - 1,
-                        right = 1,
-                        bottom = config.homeRowCount - 1,
-                        page = 0,
-                        packageName = defaultSMSMessengerPackage,
-                        activityName = "",
-                        userSerial = userSerial,
-                        title = title,
-                        type = ITEM_TYPE_ICON,
-                        className = "",
-                        widgetId = -1,
-                        shortcutId = "",
-                        icon = null,
-                        docked = true,
-                        parentId = null
-                    )
-                homeScreenGridItems.add(messengerIcon)
-            }
-        } catch (_: Exception) {
-        }
-
-        try {
-            val browserIntent = Intent(Intent.ACTION_VIEW, "http://".toUri())
-            val resolveInfo =
-                packageManager.resolveActivity(browserIntent, PackageManager.MATCH_DEFAULT_ONLY)
-            val defaultBrowserPackage = resolveInfo!!.activityInfo.packageName
-            appLaunchers.firstOrNull {
-                it.packageName == defaultBrowserPackage && it.userSerial == myUserSerial
-            }?.apply {
-                val browserIcon =
-                    HomeScreenGridItem(
-                        id = null,
-                        left = 2,
-                        top = config.homeRowCount - 1,
-                        right = 2,
-                        bottom = config.homeRowCount - 1,
-                        page = 0,
-                        packageName = defaultBrowserPackage,
-                        activityName = "",
-                        userSerial = userSerial,
-                        title = title,
-                        type = ITEM_TYPE_ICON,
-                        className = "",
-                        widgetId = -1,
-                        shortcutId = "",
-                        icon = null,
-                        docked = true,
-                        parentId = null
-                    )
-                homeScreenGridItems.add(browserIcon)
-            }
-        } catch (_: Exception) {
-        }
-
-        try {
-            val potentialStores = arrayListOf(
-                "com.android.vending", "org.fdroid.fdroid", "com.aurora.store"
-            )
-            val storePackage = potentialStores.firstOrNull {
-                isPackageInstalled(it) && appLaunchers.map { it.packageName }.contains(it)
-            }
-            if (storePackage != null) {
-                appLaunchers.firstOrNull {
-                    it.packageName == storePackage && it.userSerial == myUserSerial
-                }?.apply {
-                    val storeIcon = HomeScreenGridItem(
-                        id = null,
-                        left = 3,
-                        top = config.homeRowCount - 1,
-                        right = 3,
-                        bottom = config.homeRowCount - 1,
-                        page = 0,
-                        packageName = storePackage,
-                        activityName = "",
-                        userSerial = userSerial,
-                        title = title,
-                        type = ITEM_TYPE_ICON,
-                        className = "",
-                        widgetId = -1,
-                        shortcutId = "",
-                        icon = null,
-                        docked = true,
-                        parentId = null
-                    )
-                    homeScreenGridItems.add(storeIcon)
-                }
-            }
-        } catch (_: Exception) {
-        }
-
-        try {
-            val cameraIntent = Intent("android.media.action.IMAGE_CAPTURE")
-            val resolveInfo =
-                packageManager.resolveActivity(cameraIntent, PackageManager.MATCH_DEFAULT_ONLY)
-            val defaultCameraPackage = resolveInfo!!.activityInfo.packageName
-            appLaunchers.firstOrNull {
-                it.packageName == defaultCameraPackage && it.userSerial == myUserSerial
-            }?.apply {
-                val cameraIcon =
-                    HomeScreenGridItem(
-                        id = null,
-                        left = 4,
-                        top = config.homeRowCount - 1,
-                        right = 4,
-                        bottom = config.homeRowCount - 1,
-                        page = 0,
-                        packageName = defaultCameraPackage,
-                        activityName = "",
-                        userSerial = userSerial,
-                        title = title,
-                        type = ITEM_TYPE_ICON,
-                        className = "",
-                        widgetId = -1,
-                        shortcutId = "",
-                        icon = null,
-                        docked = true,
-                        parentId = null
-                    )
-                homeScreenGridItems.add(cameraIcon)
-            }
-        } catch (_: Exception) {
-        }
+        addDockedItemIfPresent(
+            homeScreenGridItems = homeScreenGridItems,
+            appLaunchers = appLaunchers,
+            userSerial = myUserSerial,
+            packageName = getDefaultDialerPackageOrNull(),
+            column = 0
+        )
+        addDockedItemIfPresent(
+            homeScreenGridItems = homeScreenGridItems,
+            appLaunchers = appLaunchers,
+            userSerial = myUserSerial,
+            packageName = getDefaultSmsPackageOrNull(),
+            column = 1
+        )
+        addDockedItemIfPresent(
+            homeScreenGridItems = homeScreenGridItems,
+            appLaunchers = appLaunchers,
+            userSerial = myUserSerial,
+            packageName = getDefaultBrowserPackageOrNull(),
+            column = 2
+        )
+        addDockedItemIfPresent(
+            homeScreenGridItems = homeScreenGridItems,
+            appLaunchers = appLaunchers,
+            userSerial = myUserSerial,
+            packageName = getDefaultStorePackageOrNull(appLaunchers),
+            column = 3
+        )
+        addDockedItemIfPresent(
+            homeScreenGridItems = homeScreenGridItems,
+            appLaunchers = appLaunchers,
+            userSerial = myUserSerial,
+            packageName = getDefaultCameraPackageOrNull(),
+            column = 4
+        )
 
         homeScreenGridItemsDB.insertAll(homeScreenGridItems)
     }
+
+    private fun addDockedItemIfPresent(
+        homeScreenGridItems: MutableList<HomeScreenGridItem>,
+        appLaunchers: List<AppLauncher>,
+        userSerial: Long,
+        packageName: String?,
+        column: Int,
+    ) {
+        if (packageName.isNullOrEmpty()) {
+            return
+        }
+
+        val launcher = appLaunchers.firstOrNull {
+            it.packageName == packageName && it.userSerial == userSerial
+        } ?: return
+
+        homeScreenGridItems.add(
+            createDockedItem(
+                column = column,
+                packageName = packageName,
+                launcher = launcher
+            )
+        )
+    }
+
+    private fun createDockedItem(
+        column: Int,
+        packageName: String,
+        launcher: AppLauncher,
+    ): HomeScreenGridItem {
+        val dockRow = config.homeRowCount - 1
+        return HomeScreenGridItem(
+            id = null,
+            left = column,
+            top = dockRow,
+            right = column,
+            bottom = dockRow,
+            page = 0,
+            packageName = packageName,
+            activityName = "",
+            userSerial = launcher.userSerial,
+            title = launcher.title,
+            type = ITEM_TYPE_ICON,
+            className = "",
+            widgetId = -1,
+            shortcutId = "",
+            icon = null,
+            docked = true,
+            parentId = null
+        )
+    }
+
+    private fun getDefaultDialerPackageOrNull(): String? = runCatching {
+        (getSystemService(TELECOM_SERVICE) as TelecomManager).defaultDialerPackage
+    }.getOrNull()
+
+    private fun getDefaultSmsPackageOrNull(): String? = runCatching {
+        Telephony.Sms.getDefaultSmsPackage(this)
+    }.getOrNull()
+
+    private fun getDefaultBrowserPackageOrNull(): String? = runCatching {
+        val browserIntent = Intent(Intent.ACTION_VIEW, "http://".toUri())
+        packageManager.resolveActivity(browserIntent, PackageManager.MATCH_DEFAULT_ONLY)
+            ?.activityInfo
+            ?.packageName
+    }.getOrNull()
+
+    private fun getDefaultStorePackageOrNull(appLaunchers: List<AppLauncher>): String? {
+        val launcherPackages = appLaunchers.map { it.packageName }.toSet()
+        val potentialStores = listOf(
+            "com.android.vending",
+            "org.fdroid.fdroid",
+            "com.aurora.store"
+        )
+        return runCatching {
+            potentialStores.firstOrNull { isPackageInstalled(it) && launcherPackages.contains(it) }
+        }.getOrNull()
+    }
+
+    private fun getDefaultCameraPackageOrNull(): String? = runCatching {
+        val cameraIntent = Intent("android.media.action.IMAGE_CAPTURE")
+        packageManager.resolveActivity(cameraIntent, PackageManager.MATCH_DEFAULT_ONLY)
+            ?.activityInfo
+            ?.packageName
+    }.getOrNull()
 
     fun handleWidgetBinding(
         appWidgetManager: AppWidgetManager,

--- a/app/src/main/kotlin/org/fossify/home/databases/AppsDatabase.kt
+++ b/app/src/main/kotlin/org/fossify/home/databases/AppsDatabase.kt
@@ -5,6 +5,8 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import org.fossify.home.helpers.Converters
 import org.fossify.home.interfaces.AppLaunchersDao
 import org.fossify.home.interfaces.HiddenIconsDao
@@ -15,7 +17,7 @@ import org.fossify.home.models.HomeScreenGridItem
 
 @Database(
     entities = [AppLauncher::class, HomeScreenGridItem::class, HiddenIcon::class],
-    version = 5
+    version = 6
 )
 @TypeConverters(Converters::class)
 abstract class AppsDatabase : RoomDatabase() {
@@ -28,6 +30,26 @@ abstract class AppsDatabase : RoomDatabase() {
 
     companion object {
         private var db: AppsDatabase? = null
+        private val MIGRATION_5_6 = object : Migration(5, 6) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE apps ADD COLUMN user_serial INTEGER NOT NULL DEFAULT 0"
+                )
+                database.execSQL(
+                    "ALTER TABLE home_screen_grid_items ADD COLUMN user_serial INTEGER NOT NULL DEFAULT 0"
+                )
+                database.execSQL(
+                    "ALTER TABLE hidden_icons ADD COLUMN user_serial INTEGER NOT NULL DEFAULT 0"
+                )
+                database.execSQL(
+                    "DROP INDEX IF EXISTS index_apps_package_name"
+                )
+                database.execSQL(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS index_apps_package_name_activity_name_user_serial " +
+                            "ON apps(package_name, activity_name, user_serial)"
+                )
+            }
+        }
 
         fun getInstance(context: Context): AppsDatabase {
             if (db == null) {
@@ -37,7 +59,8 @@ abstract class AppsDatabase : RoomDatabase() {
                             context.applicationContext,
                             AppsDatabase::class.java,
                             "apps.db"
-                        ).build()
+                        ).addMigrations(MIGRATION_5_6)
+                            .build()
                     }
                 }
             }

--- a/app/src/main/kotlin/org/fossify/home/databases/AppsDatabase.kt
+++ b/app/src/main/kotlin/org/fossify/home/databases/AppsDatabase.kt
@@ -15,9 +15,13 @@ import org.fossify.home.models.AppLauncher
 import org.fossify.home.models.HiddenIcon
 import org.fossify.home.models.HomeScreenGridItem
 
+private const val DATABASE_VERSION = 6
+private const val MIGRATION_FROM_5_TO_6_START_VERSION = 5
+private const val MIGRATION_FROM_5_TO_6_END_VERSION = 6
+
 @Database(
     entities = [AppLauncher::class, HomeScreenGridItem::class, HiddenIcon::class],
-    version = 6
+    version = DATABASE_VERSION
 )
 @TypeConverters(Converters::class)
 abstract class AppsDatabase : RoomDatabase() {
@@ -30,7 +34,10 @@ abstract class AppsDatabase : RoomDatabase() {
 
     companion object {
         private var db: AppsDatabase? = null
-        private val MIGRATION_5_6 = object : Migration(5, 6) {
+        private val MIGRATION_FROM_5_TO_6 = object : Migration(
+            MIGRATION_FROM_5_TO_6_START_VERSION,
+            MIGRATION_FROM_5_TO_6_END_VERSION
+        ) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL(
                     "ALTER TABLE apps ADD COLUMN user_serial INTEGER NOT NULL DEFAULT 0"
@@ -59,7 +66,7 @@ abstract class AppsDatabase : RoomDatabase() {
                             context.applicationContext,
                             AppsDatabase::class.java,
                             "apps.db"
-                        ).addMigrations(MIGRATION_5_6)
+                        ).addMigrations(MIGRATION_FROM_5_TO_6)
                             .build()
                     }
                 }

--- a/app/src/main/kotlin/org/fossify/home/fragments/AllAppsFragment.kt
+++ b/app/src/main/kotlin/org/fossify/home/fragments/AllAppsFragment.kt
@@ -125,7 +125,8 @@ class AllAppsFragment(
         launchers = appLaunchers.sortedWith(
             compareBy(
                 { it.title.normalizeString().lowercase() },
-                { it.packageName }
+                { it.packageName },
+                { it.userSerial }
             )
         )
 
@@ -141,7 +142,11 @@ class AllAppsFragment(
 
             if (getAdapter() == null) {
                 LaunchersAdapter(activity!!, this) {
-                    activity?.launchApp((it as AppLauncher).packageName, it.activityName)
+                    activity?.launchApp(
+                        (it as AppLauncher).packageName,
+                        it.activityName,
+                        it.userSerial
+                    )
                     if (activity?.config?.closeAppDrawer == true) {
                         activity?.closeAppDrawer(delayed = true)
                     }
@@ -228,6 +233,7 @@ class AllAppsFragment(
             page = 0,
             packageName = appLauncher.packageName,
             activityName = appLauncher.activityName,
+            userSerial = appLauncher.userSerial,
             title = appLauncher.title,
             type = ITEM_TYPE_ICON,
             className = "",

--- a/app/src/main/kotlin/org/fossify/home/fragments/WidgetsFragment.kt
+++ b/app/src/main/kotlin/org/fossify/home/fragments/WidgetsFragment.kt
@@ -274,7 +274,8 @@ class WidgetsFragment(context: Context, attributeSet: AttributeSet) :
             page = 0,
             packageName = appWidget.appPackageName,
             activityName = "",
-            userSerial = (context.getSystemService(Context.USER_SERVICE) as UserManager).getSerialNumberForUser(Process.myUserHandle()),
+            userSerial = (context.getSystemService(Context.USER_SERVICE) as UserManager)
+                .getSerialNumberForUser(Process.myUserHandle()),
             title = "",
             type = type,
             className = appWidget.className,

--- a/app/src/main/kotlin/org/fossify/home/fragments/WidgetsFragment.kt
+++ b/app/src/main/kotlin/org/fossify/home/fragments/WidgetsFragment.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.content.pm.LauncherApps
 import android.content.pm.PackageManager
 import android.os.Process
+import android.os.UserManager
 import android.util.AttributeSet
 import android.view.MotionEvent
 import org.fossify.commons.extensions.getProperPrimaryColor
@@ -273,6 +274,7 @@ class WidgetsFragment(context: Context, attributeSet: AttributeSet) :
             page = 0,
             packageName = appWidget.appPackageName,
             activityName = "",
+            userSerial = (context.getSystemService(Context.USER_SERVICE) as UserManager).getSerialNumberForUser(Process.myUserHandle()),
             title = "",
             type = type,
             className = appWidget.className,

--- a/app/src/main/kotlin/org/fossify/home/helpers/Constants.kt
+++ b/app/src/main/kotlin/org/fossify/home/helpers/Constants.kt
@@ -37,3 +37,4 @@ const val ITEM_TYPE_FOLDER = 3
 
 const val WIDGET_HOST_ID = 12345
 const val MAX_CLICK_DURATION = 150
+const val UNKNOWN_USER_SERIAL = -1L

--- a/app/src/main/kotlin/org/fossify/home/interfaces/AppLaunchersDao.kt
+++ b/app/src/main/kotlin/org/fossify/home/interfaces/AppLaunchersDao.kt
@@ -14,7 +14,10 @@ interface AppLaunchersDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertAll(appLaunchers: List<AppLauncher>)
 
-    @Query("DELETE FROM apps WHERE package_name = :packageName AND activity_name = :activityName AND user_serial = :userSerial")
+    @Query(
+        "DELETE FROM apps WHERE package_name = :packageName " +
+            "AND activity_name = :activityName AND user_serial = :userSerial"
+    )
     fun deleteApp(packageName: String, activityName: String, userSerial: Long)
 
     @Query("DELETE FROM apps WHERE id = :id")

--- a/app/src/main/kotlin/org/fossify/home/interfaces/AppLaunchersDao.kt
+++ b/app/src/main/kotlin/org/fossify/home/interfaces/AppLaunchersDao.kt
@@ -14,8 +14,8 @@ interface AppLaunchersDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertAll(appLaunchers: List<AppLauncher>)
 
-    @Query("DELETE FROM apps WHERE package_name = :packageName")
-    fun deleteApp(packageName: String)
+    @Query("DELETE FROM apps WHERE package_name = :packageName AND activity_name = :activityName AND user_serial = :userSerial")
+    fun deleteApp(packageName: String, activityName: String, userSerial: Long)
 
     @Query("DELETE FROM apps WHERE id = :id")
     fun deleteById(id: Long)

--- a/app/src/main/kotlin/org/fossify/home/interfaces/HomeScreenGridItemsDao.kt
+++ b/app/src/main/kotlin/org/fossify/home/interfaces/HomeScreenGridItemsDao.kt
@@ -41,10 +41,17 @@ interface HomeScreenGridItemsDao {
         deleteItemsWithParentId(id)
     }
 
-    @Query("DELETE FROM home_screen_grid_items WHERE package_name = :packageName AND activity_name = :activityName AND user_serial = :userSerial")
+    @Query(
+        "DELETE FROM home_screen_grid_items WHERE package_name = :packageName " +
+            "AND activity_name = :activityName AND user_serial = :userSerial"
+    )
     fun deleteItemByIdentifier(packageName: String, activityName: String, userSerial: Long)
 
-    @Query("DELETE FROM home_screen_grid_items WHERE parent_id IN (SELECT id FROM home_screen_grid_items WHERE package_name = :packageName AND activity_name = :activityName AND user_serial = :userSerial)")
+    @Query(
+        "DELETE FROM home_screen_grid_items WHERE parent_id IN (" +
+            "SELECT id FROM home_screen_grid_items WHERE package_name = :packageName " +
+            "AND activity_name = :activityName AND user_serial = :userSerial)"
+    )
     fun deleteItemsByParentIdentifier(packageName: String, activityName: String, userSerial: Long)
 
     @Query("UPDATE home_screen_grid_items SET `left` = `left` + :shiftBy WHERE parent_id == :folderId AND `left` > :shiftFrom AND id != :excludingId")

--- a/app/src/main/kotlin/org/fossify/home/interfaces/HomeScreenGridItemsDao.kt
+++ b/app/src/main/kotlin/org/fossify/home/interfaces/HomeScreenGridItemsDao.kt
@@ -41,11 +41,11 @@ interface HomeScreenGridItemsDao {
         deleteItemsWithParentId(id)
     }
 
-    @Query("DELETE FROM home_screen_grid_items WHERE package_name = :packageName")
-    fun deleteItemByPackageName(packageName: String)
+    @Query("DELETE FROM home_screen_grid_items WHERE package_name = :packageName AND activity_name = :activityName AND user_serial = :userSerial")
+    fun deleteItemByIdentifier(packageName: String, activityName: String, userSerial: Long)
 
-    @Query("DELETE FROM home_screen_grid_items WHERE parent_id IN (SELECT id FROM home_screen_grid_items WHERE package_name = :packageName)")
-    fun deleteItemsByParentPackageName(packageName: String)
+    @Query("DELETE FROM home_screen_grid_items WHERE parent_id IN (SELECT id FROM home_screen_grid_items WHERE package_name = :packageName AND activity_name = :activityName AND user_serial = :userSerial)")
+    fun deleteItemsByParentIdentifier(packageName: String, activityName: String, userSerial: Long)
 
     @Query("UPDATE home_screen_grid_items SET `left` = `left` + :shiftBy WHERE parent_id == :folderId AND `left` > :shiftFrom AND id != :excludingId")
     fun shiftFolderItems(folderId: Long, shiftFrom: Int, shiftBy: Int, excludingId: Long? = null)
@@ -54,8 +54,8 @@ interface HomeScreenGridItemsDao {
     fun shiftPage(shiftFrom: Int, shiftBy: Int)
 
     @Transaction
-    fun deleteByPackageName(packageName: String) {
-        deleteItemByPackageName(packageName)
-        deleteItemsByParentPackageName(packageName)
+    fun deleteByIdentifier(packageName: String, activityName: String, userSerial: Long) {
+        deleteItemByIdentifier(packageName, activityName, userSerial)
+        deleteItemsByParentIdentifier(packageName, activityName, userSerial)
     }
 }

--- a/app/src/main/kotlin/org/fossify/home/models/AppLauncher.kt
+++ b/app/src/main/kotlin/org/fossify/home/models/AppLauncher.kt
@@ -6,31 +6,42 @@ import org.fossify.commons.extensions.normalizeString
 import org.fossify.commons.helpers.SORT_BY_TITLE
 import org.fossify.commons.helpers.SORT_DESCENDING
 
-@Entity(tableName = "apps", indices = [(Index(value = ["package_name"], unique = true))])
+@Entity(
+    tableName = "apps",
+    indices = [(Index(value = ["package_name", "activity_name", "user_serial"], unique = true))]
+)
 data class AppLauncher(
     @PrimaryKey(autoGenerate = true) var id: Long?,
     @ColumnInfo(name = "title") var title: String,
     @ColumnInfo(name = "package_name") var packageName: String,
     @ColumnInfo(name = "activity_name") var activityName: String,   // some apps create multiple icons, this is needed at clicking them
+    @ColumnInfo(name = "user_serial") var userSerial: Long,
     @ColumnInfo(name = "order") var order: Int,
     @ColumnInfo(name = "thumbnail_color") var thumbnailColor: Int,
 
     @Ignore var drawable: Drawable?
 ) : Comparable<AppLauncher> {
 
-    constructor() : this(null, "", "", "", 0, 0, null)
+    constructor() : this(null, "", "", "", 0L, 0, 0, null)
 
     companion object {
         var sorting = 0
     }
 
-    override fun equals(other: Any?) = packageName.equals((other as AppLauncher).packageName, true)
+    override fun equals(other: Any?): Boolean {
+        if (other !is AppLauncher) return false
+        return packageName.equals(other.packageName, true) &&
+                activityName.equals(other.activityName, true) &&
+                userSerial == other.userSerial
+    }
 
-    override fun hashCode() = super.hashCode()
+    override fun hashCode(): Int {
+        return getLauncherIdentifier().lowercase().hashCode()
+    }
 
     fun getBubbleText() = title
 
-    fun getLauncherIdentifier() = "$packageName/$activityName"
+    fun getLauncherIdentifier() = "$packageName/$activityName/$userSerial"
 
     override fun compareTo(other: AppLauncher): Int {
         var result = when {

--- a/app/src/main/kotlin/org/fossify/home/models/HiddenIcon.kt
+++ b/app/src/main/kotlin/org/fossify/home/models/HiddenIcon.kt
@@ -8,11 +8,12 @@ data class HiddenIcon(
     @PrimaryKey(autoGenerate = true) var id: Long?,
     @ColumnInfo(name = "package_name") var packageName: String,
     @ColumnInfo(name = "activity_name") var activityName: String,
+    @ColumnInfo(name = "user_serial") var userSerial: Long,
     @ColumnInfo(name = "title") var title: String,
 
     @Ignore var drawable: Drawable? = null,
 ) {
-    constructor() : this(null, "", "", "", null)
+    constructor() : this(null, "", "", 0L, "", null)
 
-    fun getIconIdentifier() = "$packageName/$activityName"
+    fun getIconIdentifier() = "$packageName/$activityName/$userSerial"
 }

--- a/app/src/main/kotlin/org/fossify/home/models/HomeScreenGridItem.kt
+++ b/app/src/main/kotlin/org/fossify/home/models/HomeScreenGridItem.kt
@@ -19,6 +19,7 @@ data class HomeScreenGridItem(
     @ColumnInfo(name = "page") var page: Int,
     @ColumnInfo(name = "package_name") var packageName: String,
     @ColumnInfo(name = "activity_name") var activityName: String,   // needed at apps that create multiple icons at install, not just the launcher
+    @ColumnInfo(name = "user_serial") var userSerial: Long,
     @ColumnInfo(name = "title") var title: String,
     @ColumnInfo(name = "type") var type: Int,
     @ColumnInfo(name = "class_name") var className: String,
@@ -38,7 +39,7 @@ data class HomeScreenGridItem(
         const val FOLDER_MAX_CAPACITY = 16
     }
 
-    constructor() : this(null, -1, -1, -1, -1, 0, "", "", "", ITEM_TYPE_ICON, "", -1, "", null, false, null, null, null, null, 1, 1)
+    constructor() : this(null, -1, -1, -1, -1, 0, "", "", 0L, "", ITEM_TYPE_ICON, "", -1, "", null, false, null, null, null, null, 1, 1)
 
     fun getWidthInCells() = if (right == -1 || left == -1) {
         widthCells
@@ -68,7 +69,7 @@ data class HomeScreenGridItem(
         }
     }
 
-    fun getItemIdentifier() = "$packageName/$activityName"
+    fun getItemIdentifier() = "$packageName/$activityName/$userSerial"
 
     fun getTopLeft(rowCount: Int) = Point(left, getDockAdjustedTop(rowCount))
 }

--- a/app/src/main/kotlin/org/fossify/home/models/HomeScreenGridItem.kt
+++ b/app/src/main/kotlin/org/fossify/home/models/HomeScreenGridItem.kt
@@ -39,7 +39,30 @@ data class HomeScreenGridItem(
         const val FOLDER_MAX_CAPACITY = 16
     }
 
-    constructor() : this(null, -1, -1, -1, -1, 0, "", "", 0L, "", ITEM_TYPE_ICON, "", -1, "", null, false, null, null, null, null, 1, 1)
+    constructor() : this(
+        null,
+        -1,
+        -1,
+        -1,
+        -1,
+        0,
+        "",
+        "",
+        0L,
+        "",
+        ITEM_TYPE_ICON,
+        "",
+        -1,
+        "",
+        null,
+        false,
+        null,
+        null,
+        null,
+        null,
+        1,
+        1
+    )
 
     fun getWidthInCells() = if (right == -1 || left == -1) {
         widthCells

--- a/app/src/main/kotlin/org/fossify/home/views/HomeScreenGrid.kt
+++ b/app/src/main/kotlin/org/fossify/home/views/HomeScreenGrid.kt
@@ -239,7 +239,10 @@ class HomeScreenGrid(context: Context, attrs: AttributeSet, defStyle: Int) :
             gridItems = context.homeScreenGridItemsDB.getAllItems() as ArrayList<HomeScreenGridItem>
             gridItems.toImmutableList().forEach { item ->
                 if (item.type == ITEM_TYPE_ICON) {
-                    item.drawable = context.getDrawableForPackageName(item.packageName)
+                    item.drawable = context.getDrawableForPackageName(
+                        item.packageName,
+                        item.userSerial
+                    )
                 } else if (item.type == ITEM_TYPE_FOLDER) {
                     item.drawable = item.toFolder().generateDrawable()
                 } else if (item.type == ITEM_TYPE_SHORTCUT) {
@@ -362,7 +365,10 @@ class HomeScreenGrid(context: Context, attrs: AttributeSet, defStyle: Int) :
                 draggedItem!!.drawable = draggedGridItem.toFolder().generateDrawable()
             } else {
                 draggedItem!!.drawable =
-                    context.getDrawableForPackageName(draggedGridItem.packageName)
+                    context.getDrawableForPackageName(
+                        draggedGridItem.packageName,
+                        draggedGridItem.userSerial
+                    )
             }
         }
 
@@ -906,6 +912,7 @@ class HomeScreenGrid(context: Context, attrs: AttributeSet, defStyle: Int) :
                 page = pager.getCurrentPage(),
                 packageName = draggedItem!!.packageName,
                 activityName = draggedItem!!.activityName,
+                userSerial = draggedItem!!.userSerial,
                 title = draggedItem!!.title,
                 type = draggedItem!!.type,
                 className = "",
@@ -2470,4 +2477,3 @@ private class AnimatedGridPager(
             }
     }
 }
-


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Added user_serial and DB schema v6 to separate data per profile, supporting Dual Apps with Android profiles.
- Non‑breaking for existing users thanks to the v5 -> v6 migration.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
- Tested on Android 16 on a Pixel 9a and Pixel 7a.
- Test case 1: Fresh install of the profile‑supporting foss-debug APK (no existing Fossify Launcher). Searched for work‑profile apps, added them to the home-screen and launched them.
- Test case 2: Fresh install of the current upstream foss-debug APK (no profile support, commit 774a045), configured the home-screen with default‑profile apps, then upgraded to the profile‑supporting foss-debug APK and verified all existing home‑screen configurations.

#### Before & after preview
<!-- For changes affecting UI, consider attaching screenshots or a video. Delete this section otherwise. -->
- Before: apps from non‑default profiles were not visible and couldn’t be added to the home-screen:
<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/184c14fd-fbfb-4abe-a706-ad8e90b850ff" width=178 />
<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/318dcef5-55ab-4e2c-8f94-113fc958765b" width=178 />

- After: upgrading from upstream to profile supporting version:
<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/b8df9d8b-6bec-40c8-b3ab-af588e1d93ee" width=178 />

- Existing home‑screen configurations from the previously installed upstream foss-debug APK were preserved.
<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/59c980db-0da4-4b22-9823-79d5fa746604" width=178 />

- Apps from non‑default profiles are now visible, can be added to the home-screen and can be launched.
<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/1d5eaea0-5662-4705-a152-5621827e0b2b" width=178 />
<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/12fb2079-a14f-4980-b5a1-85e78a9bc06e" width=178 />


#### Closes the following issue(s)
- Closes #294 

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
