### PR TITLE
fix: Prevent app to move to a folder in another page of the launcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fixed : Prevent app to move to a folder in another page of the launcher
 
 ## [1.10.0] - 2026-02-14
 ### Added

--- a/app/src/main/kotlin/org/fossify/home/views/HomeScreenGrid.kt
+++ b/app/src/main/kotlin/org/fossify/home/views/HomeScreenGrid.kt
@@ -413,7 +413,8 @@ class HomeScreenGrid(context: Context, attrs: AttributeSet, defStyle: Int) :
             if (coveredCell != null) {
                 val coveredFolder = gridItems.firstOrNull {
                     it.type == ITEM_TYPE_FOLDER
-                            && it.left == coveredCell.x && it.top == coveredCell.y
+                        && it.left == coveredCell.x && it.top == coveredCell.y
+                        && it.page == draggedItem!!.page
                 }
 
                 if (


### PR DESCRIPTION
#### Type of change(s)
- [X] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Before, when you moved an app in the launcher to a location where there is a folder of apps (even in another page) and keep it for 500ms, it opened the folder and put the app in this folder.
- Now, it only opens the folder if you are in the current page.

#### Before & after preview
Before:
https://github.com/user-attachments/assets/4d9316f4-e378-44c6-b6be-eb8ca4e0726e

After:
https://github.com/user-attachments/assets/36973d5d-3b4b-460e-b883-94eae334daa4

#### Closes the following issue(s)
- Closes #103 

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [X] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [X] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [X] I understand every change in this pull request.
