### PR TITLE
fix: make icon/folder rename dialog follow system light/dark theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed unreadable dark-on-dark text in the icon/folder rename dialog when using light mode ([#198])
 
 ## [1.10.0] - 2026-02-14
 ### Added
@@ -130,6 +132,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#115]: https://github.com/FossifyOrg/Launcher/issues/115
 [#170]: https://github.com/FossifyOrg/Launcher/issues/170
 [#182]: https://github.com/FossifyOrg/Launcher/issues/182
+[#198]: https://github.com/FossifyOrg/Launcher/issues/198
 [#230]: https://github.com/FossifyOrg/Launcher/issues/230
 [#234]: https://github.com/FossifyOrg/Launcher/issues/234
 [#277]: https://github.com/FossifyOrg/Launcher/issues/277

--- a/app/src/main/kotlin/org/fossify/home/dialogs/RenameItemDialog.kt
+++ b/app/src/main/kotlin/org/fossify/home/dialogs/RenameItemDialog.kt
@@ -2,6 +2,8 @@ package org.fossify.home.dialogs
 
 import android.app.Activity
 import android.app.AlertDialog
+import android.view.ContextThemeWrapper
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.fossify.commons.extensions.*
 import org.fossify.commons.helpers.ensureBackgroundThread
 import org.fossify.home.databinding.DialogRenameItemBinding
@@ -15,7 +17,17 @@ class RenameItemDialog(val activity: Activity, val item: HomeScreenGridItem, val
         val view = binding.root
         binding.renameItemEdittext.setText(item.title)
 
-        activity.getAlertDialogBuilder()
+        // MainActivity uses the forced-dark LauncherTheme so it can draw over the wallpaper.
+        // Building the Material dialog from that context keeps its surface dark even in light
+        // mode, producing dark text on a dark background. Wrap the context in the proper
+        // day/night theme so the dialog follows the system theme like the rest of the app.
+        val builder = if (activity.isDynamicTheme()) {
+            MaterialAlertDialogBuilder(ContextThemeWrapper(activity, activity.getThemeId()))
+        } else {
+            activity.getAlertDialogBuilder()
+        }
+
+        builder
             .setPositiveButton(org.fossify.commons.R.string.ok, null)
             .setNegativeButton(org.fossify.commons.R.string.cancel, null)
             .apply {


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix

#### What changed and why
The folder/icon rename dialog showed dark text on a dark background in light system mode (dark mode was fine), making it unreadable.

Root cause is a dialog surface/text-color mismatch, not a hardcoded text color:
- `MainActivity` (which opens the rename dialog) is declared with `android:theme="@style/LauncherTheme"`, whose parent is `Theme.Material3.Dark.NoActionBar` — a forced-dark theme so the launcher can draw a transparent window over the wallpaper. `MainActivity.onCreate` also sets `useDynamicTheme = false`, so `BaseSimpleActivity` never calls `setTheme(getThemeId(...))` to switch to a light theme. The activity theme is therefore dark regardless of system mode.
- On Android 12+ `isDynamicTheme()` defaults to true, so commons' `getAlertDialogBuilder()` returns `MaterialAlertDialogBuilder(activity)`, inheriting that forced-dark context. `LauncherTheme` does not define `materialAlertDialogTheme`/`colorSurface`, so the dialog surface stays the default Material3 dark surface even in light mode.
- The dialog text uses `getProperTextColor()` (`you_neutral_text_color`), which is dark in day / light in night. Light mode therefore renders dark text on a dark surface = unreadable; dark mode renders light text on dark = fine.

Fix: in the dynamic-theme path, build the dialog from a `ContextThemeWrapper` carrying the proper day/night theme (`activity.getThemeId()`), so the Material dialog surface follows the system light/dark mode. This mirrors the precedent `MainActivity` already uses for its popup menu (`ContextThemeWrapper(this, getPopupMenuTheme())`). `getThemeId()` resolves to `AppTheme.Base.System.Light` in light mode / `AppTheme.Base.System` in dark mode, both of which set `materialAlertDialogTheme` and `colorSurface=you_dialog_background_color` (day/night). The non-dynamic path is left byte-for-byte identical (it already sets an explicit window background and renders correctly). `MaterialAlertDialogBuilder` subclasses `androidx.appcompat.app.AlertDialog.Builder`, so `setupDialogStuff(view, this, ...)` still type-checks.

#### Tests performed
Built the `fossDebug` variant and verified on an Android 15 (API 35) emulator:

Set Fossify as home app; forced light mode; long-pressed Phone icon -> Rename. Dialog shows light surface with dark readable 'Phone' text (fixed). Forced dark mode, reopened Rename -> dark surface with light readable text (not regressed).

Also confirmed `detekt`, `lint`, unit tests and the build all pass locally (CI-equivalent).

#### Closes the following issue(s)
- Closes #198

#### Checklist
- [x] I read the contribution guidelines.
- [x] I manually tested my changes on device/emulator.
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

---
<sub>Coded with Opus 4.8 ultracode.</sub>
