### PR TITLE
Add option to set icon label text to bold

### DIFF
--- a/app/src/main/kotlin/org/fossify/home/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/fossify/home/activities/SettingsActivity.kt
@@ -47,6 +47,7 @@ class SettingsActivity : SimpleActivity() {
         setupCustomizeColors()
         setupUseEnglish()
         setupDoubleTapToLock()
+        setupBoldIconLabels()
         setupCloseAppDrawerOnOtherAppOpen()
         setupOpenKeyboardOnAppDrawer()
         setupDrawerColumnCount()
@@ -246,6 +247,14 @@ class SettingsActivity : SimpleActivity() {
                     setupHomeColumnCount()
                 }
             }
+        }
+    }
+
+    private fun setupBoldIconLabels() {
+        binding.settingsBoldIconLabels.isChecked = config.boldIconLabels
+        binding.settingsBoldIconLabelsHolder.setOnClickListener {
+            binding.settingsBoldIconLabels.toggle()
+            config.boldIconLabels = binding.settingsBoldIconLabels.isChecked
         }
     }
 

--- a/app/src/main/kotlin/org/fossify/home/adapters/LaunchersAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/home/adapters/LaunchersAdapter.kt
@@ -1,6 +1,7 @@
 package org.fossify.home.adapters
 
 import android.annotation.SuppressLint
+import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.view.LayoutInflater
 import android.view.MotionEvent
@@ -89,6 +90,8 @@ class LaunchersAdapter(
                 binding.launcherLabel.text = launcher.title
                 binding.launcherLabel.setTextColor(textColor)
                 binding.launcherLabel.beVisibleIf(activity.config.showDrawerAppLabels)
+                val labelStyle = if (activity.config.boldIconLabels) Typeface.BOLD else Typeface.NORMAL
+                binding.launcherLabel.setTypeface(binding.launcherLabel.typeface, labelStyle)
                 binding.launcherIcon.setPadding(iconPadding, iconPadding, iconPadding, 0)
 
                 if (launcher.drawable != null && binding.launcherIcon.tag == true) {

--- a/app/src/main/kotlin/org/fossify/home/fragments/AllAppsFragment.kt
+++ b/app/src/main/kotlin/org/fossify/home/fragments/AllAppsFragment.kt
@@ -35,6 +35,7 @@ class AllAppsFragment(
     var ignoreTouches = false
 
     private var launchers = emptyList<AppLauncher>()
+    private var lastBoldIconLabels = false
 
     @SuppressLint("ClickableViewAccessibility")
     override fun setupFragment(activity: MainActivity) {
@@ -48,6 +49,8 @@ class AllAppsFragment(
 
             return@setOnTouchListener false
         }
+
+        lastBoldIconLabels = context.config.boldIconLabels
     }
 
     override fun onAttachedToWindow() {
@@ -64,7 +67,11 @@ class AllAppsFragment(
         val layoutManager = binding.allAppsGrid.layoutManager as MyGridLayoutManager
         if (layoutManager.spanCount != context.config.drawerColumnCount) {
             onConfigurationChanged()
+            lastBoldIconLabels = context.config.boldIconLabels
             // Force redraw due to changed item size
+            (binding.allAppsGrid.adapter as LaunchersAdapter).notifyDataSetChanged()
+        } else if (lastBoldIconLabels != context.config.boldIconLabels) {
+            lastBoldIconLabels = context.config.boldIconLabels
             (binding.allAppsGrid.adapter as LaunchersAdapter).notifyDataSetChanged()
         }
     }

--- a/app/src/main/kotlin/org/fossify/home/helpers/Config.kt
+++ b/app/src/main/kotlin/org/fossify/home/helpers/Config.kt
@@ -45,4 +45,8 @@ class Config(context: Context) : BaseConfig(context) {
     var showHomeAppLabels: Boolean
         get() = prefs.getBoolean(SHOW_HOME_APP_LABELS, true)
         set(showHomeAppLabels) = prefs.edit().putBoolean(SHOW_HOME_APP_LABELS, showHomeAppLabels).apply()
+
+    var boldIconLabels: Boolean
+        get() = prefs.getBoolean(BOLD_ICON_LABELS, false)
+        set(boldIconLabels) = prefs.edit().putBoolean(BOLD_ICON_LABELS, boldIconLabels).apply()
 }

--- a/app/src/main/kotlin/org/fossify/home/helpers/Constants.kt
+++ b/app/src/main/kotlin/org/fossify/home/helpers/Constants.kt
@@ -15,6 +15,7 @@ const val CLOSE_APP_DRAWER = "close_app_drawer"
 const val AUTO_SHOW_KEYBOARD_IN_APP_DRAWER = "auto_show_keyboard_in_app_drawer"
 const val SHOW_DRAWER_APP_LABELS = "show_drawer_app_labels"
 const val SHOW_HOME_APP_LABELS = "show_home_app_labels"
+const val BOLD_ICON_LABELS = "bold_icon_labels"
 
 // default home screen grid size
 const val ROW_COUNT = 6

--- a/app/src/main/kotlin/org/fossify/home/views/HomeScreenGrid.kt
+++ b/app/src/main/kotlin/org/fossify/home/views/HomeScreenGrid.kt
@@ -16,6 +16,7 @@ import android.graphics.Path
 import android.graphics.Point
 import android.graphics.Rect
 import android.graphics.RectF
+import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.os.Handler
@@ -148,25 +149,23 @@ class HomeScreenGrid(context: Context, attrs: AttributeSet, defStyle: Int) :
     init {
         ViewCompat.setAccessibilityDelegate(this, accessibilityHelper)
 
-        val customTypeface = FontHelper.getTypeface(context)
         textPaint = TextPaint(Paint.ANTI_ALIAS_FLAG).apply {
             color = Color.WHITE
             textSize = context.resources.getDimension(org.fossify.commons.R.dimen.smaller_text_size)
             setShadowLayer(2f, 0f, 0f, Color.BLACK)
-            typeface = customTypeface
         }
 
         contrastTextPaint = TextPaint(Paint.ANTI_ALIAS_FLAG).apply {
             color = context.getProperTextColor()
             textSize = context.resources.getDimension(org.fossify.commons.R.dimen.smaller_text_size)
             setShadowLayer(2f, 0f, 0f, context.getProperTextColor().getContrastColor())
-            typeface = customTypeface
         }
+        updateIconLabelTypeface()
 
         folderTitleTextPaint = TextPaint(Paint.ANTI_ALIAS_FLAG).apply {
             color = context.getProperTextColor()
             textSize = context.resources.getDimension(org.fossify.commons.R.dimen.medium_text_size)
-            typeface = customTypeface
+            typeface = FontHelper.getTypeface(context)
         }
 
         dragShadowCirclePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
@@ -285,6 +284,19 @@ class HomeScreenGrid(context: Context, attrs: AttributeSet, defStyle: Int) :
             2f, 0f, 0f, context.getProperTextColor().getContrastColor()
         )
         folderBackgroundPaint.color = context.getProperBackgroundColor()
+        updateIconLabelTypeface()
+    }
+
+    private fun updateIconLabelTypeface() {
+        val baseTypeface = FontHelper.getTypeface(context)
+        val iconLabelTypeface = if (context.config.boldIconLabels) {
+            Typeface.create(baseTypeface, Typeface.BOLD)
+        } else {
+            baseTypeface
+        }
+
+        textPaint.typeface = iconLabelTypeface
+        contrastTextPaint.typeface = iconLabelTypeface
     }
 
     fun removeAppIcon(item: HomeScreenGridItem) {

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -148,6 +148,22 @@
 
             </RelativeLayout>
 
+            <RelativeLayout
+                android:id="@+id/settings_bold_icon_labels_holder"
+                style="@style/SettingsHolderSwitchStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/ripple_background">
+
+                <org.fossify.commons.views.MyMaterialSwitch
+                    android:id="@+id/settings_bold_icon_labels"
+                    style="@style/SettingsSwitchStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/bold_icon_labels" />
+
+            </RelativeLayout>
+
             <include
                 android:id="@+id/settings_general_settings_divider"
                 layout="@layout/divider" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="home_screen_settings">Home screen</string>
     <string name="widget_too_big">Widget is too big for current home screen size</string>
     <string name="double_tap_to_lock">Double tap to lock screen</string>
+    <string name="bold_icon_labels">Bold icon labels</string>
     <string name="lock_device_admin_hint">To enable the double tap to lock screen feature, you need to grant admin permission. Note that the app cannot be uninstalled until this permission is removed.</string>
     <string name="lock_device_admin_warning">Deactivating admin permission will disable the double tap to lock screen feature.</string>
     <!--


### PR DESCRIPTION
## What changed and why
- Added a "Bold icon labels" switch in Settings that bolds app-icon labels on both the home screen and in the app drawer.
- Independent of the existing app-wide custom font option, so it composes correctly if the user has also set a custom font.

## Tests performed
- Built and installed debug build on a Pixel 7 (API 35) emulator, set as default launcher.
- Toggling the setting in Settings immediately re-renders the app drawer labels bold/normal, confirmed mid-session (no relaunch needed).
- Toggled back off and confirmed it reverts.
- Home screen grid (canvas-drawn labels) uses the identical refresh path (`updateColors()` on resume) verified working for the drawer; not independently screenshotted due to ADB drag-and-drop limitations in this environment.
- `./gradlew :app:compileFossDebugKotlin` and `./gradlew detekt` both clean.

## Closes the following issue(s)
Closes #101